### PR TITLE
Add schema definitions to component base

### DIFF
--- a/README.md
+++ b/README.md
@@ -493,6 +493,74 @@ if __name__ == "__main__":
         logging.exception(exc)
         exit(2)
 ```
+
+## Table Schemas in ComponentBase
+
+In cases of a static schemas of output/input tables, the schemas can be defined using a JSON Table Schema.
+For output mapping these json schemas can be automatically turned into out table definitions.
+
+### JSON Table Schema example file
+
+```json
+{
+  "name": "product",
+  "description": "this table holds data on products",
+  "parent_tables": [],
+  "primary_keys": [
+    "id"
+  ],
+  "fields": [
+    {
+      "name": "id",
+      "base_type": "string",
+      "description": "ID of the product",
+      "length": "100",
+      "nullable": false
+    },
+    {
+      "name": "name",
+      "base_type": "string",
+      "description": "Plain-text name of the product",
+      "length": "1000",
+      "default": "Default Name"
+    }
+  ]
+}
+```
+
+### Out table definition from schema example
+
+The example below shows how a table definition can be created from a json schema using the ComponentBase. 
+The schema is located in the 'src/schemas' directory.
+
+ ```python
+import csv
+from keboola.component.base import ComponentBase
+
+DUMMY_PRODUCT_DATA = [{"id": "P0001",
+                       "name": "juice"},
+                      {"id": "P0002",
+                       "name": "chocolate bar"},
+                      {"id": "P0003",
+                       "name": "Stylish Pants"},
+                      ]
+
+
+class Component(ComponentBase):
+
+    def __init__(self):
+        super().__init__()
+
+    def run(self):
+        product_table = self.create_out_table_definition_from_schema_name("product")
+        with open(product_table.full_path, 'w') as outfile:
+            writer = csv.DictWriter(outfile, fieldnames=product_table.columns)
+            writer.writerows(DUMMY_PRODUCT_DATA)
+        self.write_manifest(product_table)
+ ```
+
+
+
  
 ## License
 

--- a/README.md
+++ b/README.md
@@ -552,7 +552,8 @@ class Component(ComponentBase):
         super().__init__()
 
     def run(self):
-        product_table = self.create_out_table_definition_from_schema_name("product")
+        product_schema = self.get_table_schema_by_name('product')
+        product_table = self.create_out_table_definition_from_schema(product_schema)
         with open(product_table.full_path, 'w') as outfile:
             writer = csv.DictWriter(outfile, fieldnames=product_table.columns)
             writer.writerows(DUMMY_PRODUCT_DATA)

--- a/docs/base.html
+++ b/docs/base.html
@@ -28,11 +28,12 @@
 </summary>
 <pre><code class="python">import logging
 import os
+import json
 from . import dao
 from . import table_schema as ts
 from abc import ABC, abstractmethod
 from pathlib import Path
-from typing import Optional
+from typing import Optional, Dict
 from .interface import CommonInterface
 
 KEY_DEBUG = &#39;debug&#39;
@@ -165,19 +166,17 @@ class ComponentBase(ABC, CommonInterface):
             raise AttributeError(f&#34;The defined action {action} is not implemented!&#34;) from e
         return action_method()
 
-    def create_out_table_definition_from_schema_name(self, schema_name: str, is_sliced: bool = False,
-                                                     destination: str = &#39;&#39;, incremental: bool = None,
-                                                     enclosure: str = &#39;&#34;&#39;, delimiter: str = &#39;,&#39;,
-                                                     delete_where: dict = None) -&gt; dao.TableDefinition:
+    def create_out_table_definition_from_schema(self, table_schema: ts.TableSchema, is_sliced: bool = False,
+                                                destination: str = &#39;&#39;, incremental: bool = None,
+                                                enclosure: str = &#39;&#34;&#39;, delimiter: str = &#39;,&#39;,
+                                                delete_where: dict = None) -&gt; dao.TableDefinition:
         &#34;&#34;&#34;
             Creates an out table definition using a defined table schema.
-            The method finds a given table schema based on a given name in a defined schema_folder_path and generates
-            a TableSchema object. From this object, the table metadata is generated and used to populate the table
-            definition.
+            This method uses the given table schema and generates metadata of the table. Along with the additional
+            key word arguments it creates an out table definition.
 
             Args:
-                schema_name : name of the schema in the schema_folder_path. e.g. for schema in &#39;schemas/output.json&#39;
-                              schema_name is &#39;output&#39;
+                table_schema : table of the schema for which a table definition will be created
                 is_sliced: True if the full_path points to a folder with sliced tables
                 destination: String name of the table in Storage.
                 incremental: Set to true to enable incremental loading
@@ -189,11 +188,6 @@ class ComponentBase(ABC, CommonInterface):
                 TableDefinition object initialized with all table metadata defined in a schema
 
         &#34;&#34;&#34;
-        if not self.schema_folder_path:
-            raise FileNotFoundError(&#34;A schema folder path must be defined in order to create a out table definition &#34;
-                                    &#34;from a schema. If a schema folder path is not defined, the schemas folder must be&#34;
-                                    &#34; located in the &#39;src&#39; directory of a component : src/schemas&#34;)
-        table_schema = ts.get_schema_by_name(schema_name, self.schema_folder_path)
         table_metadata = self._generate_table_metadata(table_schema)
         return self.create_out_table_definition(name=table_schema.csv_name,
                                                 columns=table_schema.field_names,
@@ -205,6 +199,47 @@ class ComponentBase(ABC, CommonInterface):
                                                 enclosure=enclosure,
                                                 delimiter=delimiter,
                                                 delete_where=delete_where)
+
+    def get_table_schema_by_name(self, schema_name: str,
+                                 schema_folder_path: Optional[str] = None) -&gt; ts.TableSchema:
+        &#34;&#34;&#34;
+            The method finds a table schema JSON based on it&#39;s name in a defined schema_folder_path and generates
+            a TableSchema object.
+
+            Args:
+                schema_name : name of the schema in the schema_folder_path. e.g. for schema in &#39;src/schemas/order.json&#39;
+                              schema_name is &#39;order&#39;
+                schema_folder_path : directory path to the schema folder, by default the schema folder is set at
+                                     &#39;src/schemas&#39;
+            Returns:
+                TableSchema object initialized with all available table metadata
+
+
+        &#34;&#34;&#34;
+        if not schema_folder_path:
+            schema_folder_path = self.schema_folder_path
+        self._validate_schema_folder_path(schema_folder_path)
+        schema_dict = self._load_table_schema_dict(schema_name, schema_folder_path)
+        return ts.init_table_schema_from_dict(schema_dict)
+
+    @staticmethod
+    def _load_table_schema_dict(schema_name: str, schema_folder_path: str) -&gt; Dict:
+        try:
+            with open(os.path.join(schema_folder_path, f&#34;{schema_name}.json&#34;), &#39;r&#39;) as schema_file:
+                json_schema = json.loads(schema_file.read())
+        except FileNotFoundError as file_err:
+            raise FileNotFoundError(
+                f&#34;Schema for corresponding schema name : {schema_name} is not found in the schema directory. &#34;
+                f&#34;Make sure that &#39;{schema_name}&#39;.json &#34;
+                f&#34;exists in the directory &#39;{schema_folder_path}&#39;&#34;) from file_err
+        return json_schema
+
+    @staticmethod
+    def _validate_schema_folder_path(schema_folder_path: str):
+        if not schema_folder_path or not os.path.isdir(schema_folder_path):
+            raise FileNotFoundError(&#34;A schema folder path must be defined in order to create a out table definition &#34;
+                                    &#34;from a schema. If a schema folder path is not defined, the schemas folder must be&#34;
+                                    &#34; located in the &#39;src&#39; directory of a component : src/schemas&#34;)
 
     def _generate_table_metadata(self, table_schema: ts.TableSchema) -&gt; dao.TableMetadata:
         &#34;&#34;&#34;
@@ -399,19 +434,17 @@ validation is done at constructor level</p>
             raise AttributeError(f&#34;The defined action {action} is not implemented!&#34;) from e
         return action_method()
 
-    def create_out_table_definition_from_schema_name(self, schema_name: str, is_sliced: bool = False,
-                                                     destination: str = &#39;&#39;, incremental: bool = None,
-                                                     enclosure: str = &#39;&#34;&#39;, delimiter: str = &#39;,&#39;,
-                                                     delete_where: dict = None) -&gt; dao.TableDefinition:
+    def create_out_table_definition_from_schema(self, table_schema: ts.TableSchema, is_sliced: bool = False,
+                                                destination: str = &#39;&#39;, incremental: bool = None,
+                                                enclosure: str = &#39;&#34;&#39;, delimiter: str = &#39;,&#39;,
+                                                delete_where: dict = None) -&gt; dao.TableDefinition:
         &#34;&#34;&#34;
             Creates an out table definition using a defined table schema.
-            The method finds a given table schema based on a given name in a defined schema_folder_path and generates
-            a TableSchema object. From this object, the table metadata is generated and used to populate the table
-            definition.
+            This method uses the given table schema and generates metadata of the table. Along with the additional
+            key word arguments it creates an out table definition.
 
             Args:
-                schema_name : name of the schema in the schema_folder_path. e.g. for schema in &#39;schemas/output.json&#39;
-                              schema_name is &#39;output&#39;
+                table_schema : table of the schema for which a table definition will be created
                 is_sliced: True if the full_path points to a folder with sliced tables
                 destination: String name of the table in Storage.
                 incremental: Set to true to enable incremental loading
@@ -423,11 +456,6 @@ validation is done at constructor level</p>
                 TableDefinition object initialized with all table metadata defined in a schema
 
         &#34;&#34;&#34;
-        if not self.schema_folder_path:
-            raise FileNotFoundError(&#34;A schema folder path must be defined in order to create a out table definition &#34;
-                                    &#34;from a schema. If a schema folder path is not defined, the schemas folder must be&#34;
-                                    &#34; located in the &#39;src&#39; directory of a component : src/schemas&#34;)
-        table_schema = ts.get_schema_by_name(schema_name, self.schema_folder_path)
         table_metadata = self._generate_table_metadata(table_schema)
         return self.create_out_table_definition(name=table_schema.csv_name,
                                                 columns=table_schema.field_names,
@@ -439,6 +467,47 @@ validation is done at constructor level</p>
                                                 enclosure=enclosure,
                                                 delimiter=delimiter,
                                                 delete_where=delete_where)
+
+    def get_table_schema_by_name(self, schema_name: str,
+                                 schema_folder_path: Optional[str] = None) -&gt; ts.TableSchema:
+        &#34;&#34;&#34;
+            The method finds a table schema JSON based on it&#39;s name in a defined schema_folder_path and generates
+            a TableSchema object.
+
+            Args:
+                schema_name : name of the schema in the schema_folder_path. e.g. for schema in &#39;src/schemas/order.json&#39;
+                              schema_name is &#39;order&#39;
+                schema_folder_path : directory path to the schema folder, by default the schema folder is set at
+                                     &#39;src/schemas&#39;
+            Returns:
+                TableSchema object initialized with all available table metadata
+
+
+        &#34;&#34;&#34;
+        if not schema_folder_path:
+            schema_folder_path = self.schema_folder_path
+        self._validate_schema_folder_path(schema_folder_path)
+        schema_dict = self._load_table_schema_dict(schema_name, schema_folder_path)
+        return ts.init_table_schema_from_dict(schema_dict)
+
+    @staticmethod
+    def _load_table_schema_dict(schema_name: str, schema_folder_path: str) -&gt; Dict:
+        try:
+            with open(os.path.join(schema_folder_path, f&#34;{schema_name}.json&#34;), &#39;r&#39;) as schema_file:
+                json_schema = json.loads(schema_file.read())
+        except FileNotFoundError as file_err:
+            raise FileNotFoundError(
+                f&#34;Schema for corresponding schema name : {schema_name} is not found in the schema directory. &#34;
+                f&#34;Make sure that &#39;{schema_name}&#39;.json &#34;
+                f&#34;exists in the directory &#39;{schema_folder_path}&#39;&#34;) from file_err
+        return json_schema
+
+    @staticmethod
+    def _validate_schema_folder_path(schema_folder_path: str):
+        if not schema_folder_path or not os.path.isdir(schema_folder_path):
+            raise FileNotFoundError(&#34;A schema folder path must be defined in order to create a out table definition &#34;
+                                    &#34;from a schema. If a schema folder path is not defined, the schemas folder must be&#34;
+                                    &#34; located in the &#39;src&#39; directory of a component : src/schemas&#34;)
 
     def _generate_table_metadata(self, table_schema: ts.TableSchema) -&gt; dao.TableMetadata:
         &#34;&#34;&#34;
@@ -498,18 +567,16 @@ def set_debug_mode():
 </dl>
 <h3>Methods</h3>
 <dl>
-<dt id="keboola.component.base.ComponentBase.create_out_table_definition_from_schema_name"><code class="name flex">
-<span>def <span class="ident">create_out_table_definition_from_schema_name</span></span>(<span>self, schema_name: str, is_sliced: bool = False, destination: str = '', incremental: bool = None, enclosure: str = '"', delimiter: str = ',', delete_where: dict = None) ‑> <a title="keboola.component.dao.TableDefinition" href="dao.html#keboola.component.dao.TableDefinition">TableDefinition</a></span>
+<dt id="keboola.component.base.ComponentBase.create_out_table_definition_from_schema"><code class="name flex">
+<span>def <span class="ident">create_out_table_definition_from_schema</span></span>(<span>self, table_schema: <a title="keboola.component.table_schema.TableSchema" href="table_schema.html#keboola.component.table_schema.TableSchema">TableSchema</a>, is_sliced: bool = False, destination: str = '', incremental: bool = None, enclosure: str = '"', delimiter: str = ',', delete_where: dict = None) ‑> <a title="keboola.component.dao.TableDefinition" href="dao.html#keboola.component.dao.TableDefinition">TableDefinition</a></span>
 </code></dt>
 <dd>
 <div class="desc"><p>Creates an out table definition using a defined table schema.
-The method finds a given table schema based on a given name in a defined schema_folder_path and generates
-a TableSchema object. From this object, the table metadata is generated and used to populate the table
-definition.</p>
+This method uses the given table schema and generates metadata of the table. Along with the additional
+key word arguments it creates an out table definition.</p>
 <h2 id="args">Args</h2>
 <dl>
-<dt>schema_name : name of the schema in the schema_folder_path. e.g. for schema in 'schemas/output.json'</dt>
-<dt>schema_name is 'output'</dt>
+<dt>table_schema : table of the schema for which a table definition will be created</dt>
 <dt><strong><code>is_sliced</code></strong></dt>
 <dd>True if the full_path points to a folder with sliced tables</dd>
 <dt><strong><code>destination</code></strong></dt>
@@ -529,19 +596,17 @@ definition.</p>
 <summary>
 <span>Expand source code</span>
 </summary>
-<pre><code class="python">def create_out_table_definition_from_schema_name(self, schema_name: str, is_sliced: bool = False,
-                                                 destination: str = &#39;&#39;, incremental: bool = None,
-                                                 enclosure: str = &#39;&#34;&#39;, delimiter: str = &#39;,&#39;,
-                                                 delete_where: dict = None) -&gt; dao.TableDefinition:
+<pre><code class="python">def create_out_table_definition_from_schema(self, table_schema: ts.TableSchema, is_sliced: bool = False,
+                                            destination: str = &#39;&#39;, incremental: bool = None,
+                                            enclosure: str = &#39;&#34;&#39;, delimiter: str = &#39;,&#39;,
+                                            delete_where: dict = None) -&gt; dao.TableDefinition:
     &#34;&#34;&#34;
         Creates an out table definition using a defined table schema.
-        The method finds a given table schema based on a given name in a defined schema_folder_path and generates
-        a TableSchema object. From this object, the table metadata is generated and used to populate the table
-        definition.
+        This method uses the given table schema and generates metadata of the table. Along with the additional
+        key word arguments it creates an out table definition.
 
         Args:
-            schema_name : name of the schema in the schema_folder_path. e.g. for schema in &#39;schemas/output.json&#39;
-                          schema_name is &#39;output&#39;
+            table_schema : table of the schema for which a table definition will be created
             is_sliced: True if the full_path points to a folder with sliced tables
             destination: String name of the table in Storage.
             incremental: Set to true to enable incremental loading
@@ -553,11 +618,6 @@ definition.</p>
             TableDefinition object initialized with all table metadata defined in a schema
 
     &#34;&#34;&#34;
-    if not self.schema_folder_path:
-        raise FileNotFoundError(&#34;A schema folder path must be defined in order to create a out table definition &#34;
-                                &#34;from a schema. If a schema folder path is not defined, the schemas folder must be&#34;
-                                &#34; located in the &#39;src&#39; directory of a component : src/schemas&#34;)
-    table_schema = ts.get_schema_by_name(schema_name, self.schema_folder_path)
     table_metadata = self._generate_table_metadata(table_schema)
     return self.create_out_table_definition(name=table_schema.csv_name,
                                             columns=table_schema.field_names,
@@ -596,6 +656,46 @@ The default action is 'run'.</p></div>
     except AttributeError as e:
         raise AttributeError(f&#34;The defined action {action} is not implemented!&#34;) from e
     return action_method()</code></pre>
+</details>
+</dd>
+<dt id="keboola.component.base.ComponentBase.get_table_schema_by_name"><code class="name flex">
+<span>def <span class="ident">get_table_schema_by_name</span></span>(<span>self, schema_name: str, schema_folder_path: Optional[str] = None) ‑> <a title="keboola.component.table_schema.TableSchema" href="table_schema.html#keboola.component.table_schema.TableSchema">TableSchema</a></span>
+</code></dt>
+<dd>
+<div class="desc"><p>The method finds a table schema JSON based on it's name in a defined schema_folder_path and generates
+a TableSchema object.</p>
+<h2 id="args">Args</h2>
+<p>schema_name : name of the schema in the schema_folder_path. e.g. for schema in 'src/schemas/order.json'
+schema_name is 'order'
+schema_folder_path : directory path to the schema folder, by default the schema folder is set at
+'src/schemas'</p>
+<h2 id="returns">Returns</h2>
+<p>TableSchema object initialized with all available table metadata</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def get_table_schema_by_name(self, schema_name: str,
+                             schema_folder_path: Optional[str] = None) -&gt; ts.TableSchema:
+    &#34;&#34;&#34;
+        The method finds a table schema JSON based on it&#39;s name in a defined schema_folder_path and generates
+        a TableSchema object.
+
+        Args:
+            schema_name : name of the schema in the schema_folder_path. e.g. for schema in &#39;src/schemas/order.json&#39;
+                          schema_name is &#39;order&#39;
+            schema_folder_path : directory path to the schema folder, by default the schema folder is set at
+                                 &#39;src/schemas&#39;
+        Returns:
+            TableSchema object initialized with all available table metadata
+
+
+    &#34;&#34;&#34;
+    if not schema_folder_path:
+        schema_folder_path = self.schema_folder_path
+    self._validate_schema_folder_path(schema_folder_path)
+    schema_dict = self._load_table_schema_dict(schema_name, schema_folder_path)
+    return ts.init_table_schema_from_dict(schema_dict)</code></pre>
 </details>
 </dd>
 <dt id="keboola.component.base.ComponentBase.run"><code class="name flex">
@@ -665,8 +765,9 @@ def run(self):
 <li>
 <h4><code><a title="keboola.component.base.ComponentBase" href="#keboola.component.base.ComponentBase">ComponentBase</a></code></h4>
 <ul class="">
-<li><code><a title="keboola.component.base.ComponentBase.create_out_table_definition_from_schema_name" href="#keboola.component.base.ComponentBase.create_out_table_definition_from_schema_name">create_out_table_definition_from_schema_name</a></code></li>
+<li><code><a title="keboola.component.base.ComponentBase.create_out_table_definition_from_schema" href="#keboola.component.base.ComponentBase.create_out_table_definition_from_schema">create_out_table_definition_from_schema</a></code></li>
 <li><code><a title="keboola.component.base.ComponentBase.execute_action" href="#keboola.component.base.ComponentBase.execute_action">execute_action</a></code></li>
+<li><code><a title="keboola.component.base.ComponentBase.get_table_schema_by_name" href="#keboola.component.base.ComponentBase.get_table_schema_by_name">get_table_schema_by_name</a></code></li>
 <li><code><a title="keboola.component.base.ComponentBase.run" href="#keboola.component.base.ComponentBase.run">run</a></code></li>
 <li><code><a title="keboola.component.base.ComponentBase.set_debug_mode" href="#keboola.component.base.ComponentBase.set_debug_mode">set_debug_mode</a></code></li>
 </ul>

--- a/docs/base.html
+++ b/docs/base.html
@@ -191,8 +191,8 @@ class ComponentBase(ABC, CommonInterface):
         &#34;&#34;&#34;
         if not self.schema_folder_path:
             raise FileNotFoundError(&#34;A schema folder path must be defined in order to create a out table definition &#34;
-                                    &#34;from a schema. If a schema folder path is not defined, the schemas folder must be &#34;
-                                    &#34;located in the &#39;src&#39; directory of a component : src/schemas&#34;)
+                                    &#34;from a schema. If a schema folder path is not defined, the schemas folder must be&#34;
+                                    &#34; located in the &#39;src&#39; directory of a component : src/schemas&#34;)
         table_schema = ts.get_schema_by_name(schema_name, self.schema_folder_path)
         table_metadata = self._generate_table_metadata(table_schema)
         return self.create_out_table_definition(name=table_schema.csv_name,
@@ -425,8 +425,8 @@ validation is done at constructor level</p>
         &#34;&#34;&#34;
         if not self.schema_folder_path:
             raise FileNotFoundError(&#34;A schema folder path must be defined in order to create a out table definition &#34;
-                                    &#34;from a schema. If a schema folder path is not defined, the schemas folder must be &#34;
-                                    &#34;located in the &#39;src&#39; directory of a component : src/schemas&#34;)
+                                    &#34;from a schema. If a schema folder path is not defined, the schemas folder must be&#34;
+                                    &#34; located in the &#39;src&#39; directory of a component : src/schemas&#34;)
         table_schema = ts.get_schema_by_name(schema_name, self.schema_folder_path)
         table_metadata = self._generate_table_metadata(table_schema)
         return self.create_out_table_definition(name=table_schema.csv_name,
@@ -555,8 +555,8 @@ definition.</p>
     &#34;&#34;&#34;
     if not self.schema_folder_path:
         raise FileNotFoundError(&#34;A schema folder path must be defined in order to create a out table definition &#34;
-                                &#34;from a schema. If a schema folder path is not defined, the schemas folder must be &#34;
-                                &#34;located in the &#39;src&#39; directory of a component : src/schemas&#34;)
+                                &#34;from a schema. If a schema folder path is not defined, the schemas folder must be&#34;
+                                &#34; located in the &#39;src&#39; directory of a component : src/schemas&#34;)
     table_schema = ts.get_schema_by_name(schema_name, self.schema_folder_path)
     table_metadata = self._generate_table_metadata(table_schema)
     return self.create_out_table_definition(name=table_schema.csv_name,

--- a/docs/base.html
+++ b/docs/base.html
@@ -28,10 +28,11 @@
 </summary>
 <pre><code class="python">import logging
 import os
+from . import dao
+from . import table_schema as ts
 from abc import ABC, abstractmethod
 from pathlib import Path
 from typing import Optional
-
 from .interface import CommonInterface
 
 KEY_DEBUG = &#39;debug&#39;
@@ -39,6 +40,7 @@ KEY_DEBUG = &#39;debug&#39;
 
 class ComponentBase(ABC, CommonInterface):
     def __init__(self, data_path_override: Optional[str] = None,
+                 schema_path_override: Optional[str] = None,
                  required_parameters: Optional[list] = None,
                  required_image_parameters: Optional[list] = None):
         &#34;&#34;&#34;
@@ -75,7 +77,10 @@ class ComponentBase(ABC, CommonInterface):
         if self.configuration.parameters.get(KEY_DEBUG):
             self.set_debug_mode()
 
-    def _get_default_data_path(self) -&gt; str:
+        self.schema_folder_path = self._get_schema_folder_path(schema_path_override)
+
+    @staticmethod
+    def _get_default_data_path() -&gt; str:
         &#34;&#34;&#34;
         Returns default data_path, by default `../data` is used, relative to working directory.
         This helps with local development.
@@ -104,6 +109,27 @@ class ComponentBase(ABC, CommonInterface):
         elif not os.environ.get(&#39;KBC_DATADIR&#39;):
             data_folder_path = self._get_default_data_path()
         return data_folder_path
+
+    def _get_schema_folder_path(self, schema_path_override: str = None) -&gt; str:
+        &#34;&#34;&#34;
+            Returns value of the schema_folder_path in case the schema_path_override variable is provided or
+            the default schema_folder_path is found.
+
+        &#34;&#34;&#34;
+        return schema_path_override or self._get_default_schema_folder_path()
+
+    @staticmethod
+    def _get_default_schema_folder_path() -&gt; Optional[str]:
+        &#34;&#34;&#34;
+             Finds the default schema_folder_path if it exists.
+
+        &#34;&#34;&#34;
+        container_schema_dir = Path(&#34;./src/schemas/&#34;).absolute().as_posix()
+        local_schema_dir = Path(&#34;./schemas&#34;).absolute().as_posix()
+        if os.path.isdir(container_schema_dir):
+            return container_schema_dir
+        elif os.path.isdir(local_schema_dir):
+            return local_schema_dir
 
     @staticmethod
     def set_debug_mode():
@@ -137,7 +163,76 @@ class ComponentBase(ABC, CommonInterface):
             action_method = getattr(self, action)
         except AttributeError as e:
             raise AttributeError(f&#34;The defined action {action} is not implemented!&#34;) from e
-        return action_method()</code></pre>
+        return action_method()
+
+    def create_out_table_definition_from_schema_name(self, schema_name: str, is_sliced: bool = False,
+                                                     destination: str = &#39;&#39;, incremental: bool = None,
+                                                     enclosure: str = &#39;&#34;&#39;, delimiter: str = &#39;,&#39;,
+                                                     delete_where: dict = None) -&gt; dao.TableDefinition:
+        &#34;&#34;&#34;
+            Creates an out table definition using a defined table schema.
+            The method finds a given table schema based on a given name in a defined schema_folder_path and generates
+            a TableSchema object. From this object, the table metadata is generated and used to populate the table
+            definition.
+
+            Args:
+                schema_name : name of the schema in the schema_folder_path. e.g. for schema in &#39;schemas/output.json&#39;
+                              schema_name is &#39;output&#39;
+                is_sliced: True if the full_path points to a folder with sliced tables
+                destination: String name of the table in Storage.
+                incremental: Set to true to enable incremental loading
+                enclosure: str: CSV enclosure, by default &#34;
+                delimiter: str: CSV delimiter, by default ,
+                delete_where: Dict with settings for deleting rows
+
+            Returns:
+                TableDefinition object initialized with all table metadata defined in a schema
+
+        &#34;&#34;&#34;
+        if not self.schema_folder_path:
+            raise FileNotFoundError(&#34;A schema folder path must be defined in order to create a out table definition &#34;
+                                    &#34;from a schema. If a schema folder path is not defined, the schemas folder must be &#34;
+                                    &#34;located in the &#39;src&#39; directory of a component : src/schemas&#34;)
+        table_schema = ts.get_schema_by_name(schema_name, self.schema_folder_path)
+        table_metadata = self._generate_table_metadata(table_schema)
+        return self.create_out_table_definition(name=table_schema.csv_name,
+                                                columns=table_schema.field_names,
+                                                primary_key=table_schema.primary_keys,
+                                                table_metadata=table_metadata,
+                                                is_sliced=is_sliced,
+                                                destination=destination,
+                                                incremental=incremental,
+                                                enclosure=enclosure,
+                                                delimiter=delimiter,
+                                                delete_where=delete_where)
+
+    def _generate_table_metadata(self, table_schema: ts.TableSchema) -&gt; dao.TableMetadata:
+        &#34;&#34;&#34;
+            Generates a TableMetadata object for the table definition using a TableSchema object.
+
+        &#34;&#34;&#34;
+        table_metadata = dao.TableMetadata()
+        if table_schema.description:
+            table_metadata.add_table_description(table_schema.description)
+        table_metadata.add_column_descriptions({field.name: field.description for field in table_schema.fields})
+        table_metadata = self._add_field_data_types_to_table_metadata(table_schema, table_metadata)
+        return table_metadata
+
+    @staticmethod
+    def _add_field_data_types_to_table_metadata(table_schema: ts.TableSchema,
+                                                table_metadata: dao.TableMetadata) -&gt; dao.TableMetadata:
+        &#34;&#34;&#34;
+            Adds data types of all fields specified in a TableSchema object to a given TableMetadata object
+
+        &#34;&#34;&#34;
+        for field in table_schema.fields:
+            if field.base_type:
+                table_metadata.add_column_data_type(field.name,
+                                                    data_type=field.base_type,
+                                                    nullable=field.nullable,
+                                                    length=field.length,
+                                                    default=field.default)
+        return table_metadata</code></pre>
 </details>
 </section>
 <section>
@@ -151,7 +246,7 @@ class ComponentBase(ABC, CommonInterface):
 <dl>
 <dt id="keboola.component.base.ComponentBase"><code class="flex name class">
 <span>class <span class="ident">ComponentBase</span></span>
-<span>(</span><span>data_path_override: Optional[str] = None, required_parameters: Optional[list] = None, required_image_parameters: Optional[list] = None)</span>
+<span>(</span><span>data_path_override: Optional[str] = None, schema_path_override: Optional[str] = None, required_parameters: Optional[list] = None, required_image_parameters: Optional[list] = None)</span>
 </code></dt>
 <dd>
 <div class="desc"><p>Helper class that provides a standard way to create an ABC using
@@ -179,6 +274,7 @@ validation is done at constructor level</p>
 </summary>
 <pre><code class="python">class ComponentBase(ABC, CommonInterface):
     def __init__(self, data_path_override: Optional[str] = None,
+                 schema_path_override: Optional[str] = None,
                  required_parameters: Optional[list] = None,
                  required_image_parameters: Optional[list] = None):
         &#34;&#34;&#34;
@@ -215,7 +311,10 @@ validation is done at constructor level</p>
         if self.configuration.parameters.get(KEY_DEBUG):
             self.set_debug_mode()
 
-    def _get_default_data_path(self) -&gt; str:
+        self.schema_folder_path = self._get_schema_folder_path(schema_path_override)
+
+    @staticmethod
+    def _get_default_data_path() -&gt; str:
         &#34;&#34;&#34;
         Returns default data_path, by default `../data` is used, relative to working directory.
         This helps with local development.
@@ -244,6 +343,27 @@ validation is done at constructor level</p>
         elif not os.environ.get(&#39;KBC_DATADIR&#39;):
             data_folder_path = self._get_default_data_path()
         return data_folder_path
+
+    def _get_schema_folder_path(self, schema_path_override: str = None) -&gt; str:
+        &#34;&#34;&#34;
+            Returns value of the schema_folder_path in case the schema_path_override variable is provided or
+            the default schema_folder_path is found.
+
+        &#34;&#34;&#34;
+        return schema_path_override or self._get_default_schema_folder_path()
+
+    @staticmethod
+    def _get_default_schema_folder_path() -&gt; Optional[str]:
+        &#34;&#34;&#34;
+             Finds the default schema_folder_path if it exists.
+
+        &#34;&#34;&#34;
+        container_schema_dir = Path(&#34;./src/schemas/&#34;).absolute().as_posix()
+        local_schema_dir = Path(&#34;./schemas&#34;).absolute().as_posix()
+        if os.path.isdir(container_schema_dir):
+            return container_schema_dir
+        elif os.path.isdir(local_schema_dir):
+            return local_schema_dir
 
     @staticmethod
     def set_debug_mode():
@@ -277,7 +397,76 @@ validation is done at constructor level</p>
             action_method = getattr(self, action)
         except AttributeError as e:
             raise AttributeError(f&#34;The defined action {action} is not implemented!&#34;) from e
-        return action_method()</code></pre>
+        return action_method()
+
+    def create_out_table_definition_from_schema_name(self, schema_name: str, is_sliced: bool = False,
+                                                     destination: str = &#39;&#39;, incremental: bool = None,
+                                                     enclosure: str = &#39;&#34;&#39;, delimiter: str = &#39;,&#39;,
+                                                     delete_where: dict = None) -&gt; dao.TableDefinition:
+        &#34;&#34;&#34;
+            Creates an out table definition using a defined table schema.
+            The method finds a given table schema based on a given name in a defined schema_folder_path and generates
+            a TableSchema object. From this object, the table metadata is generated and used to populate the table
+            definition.
+
+            Args:
+                schema_name : name of the schema in the schema_folder_path. e.g. for schema in &#39;schemas/output.json&#39;
+                              schema_name is &#39;output&#39;
+                is_sliced: True if the full_path points to a folder with sliced tables
+                destination: String name of the table in Storage.
+                incremental: Set to true to enable incremental loading
+                enclosure: str: CSV enclosure, by default &#34;
+                delimiter: str: CSV delimiter, by default ,
+                delete_where: Dict with settings for deleting rows
+
+            Returns:
+                TableDefinition object initialized with all table metadata defined in a schema
+
+        &#34;&#34;&#34;
+        if not self.schema_folder_path:
+            raise FileNotFoundError(&#34;A schema folder path must be defined in order to create a out table definition &#34;
+                                    &#34;from a schema. If a schema folder path is not defined, the schemas folder must be &#34;
+                                    &#34;located in the &#39;src&#39; directory of a component : src/schemas&#34;)
+        table_schema = ts.get_schema_by_name(schema_name, self.schema_folder_path)
+        table_metadata = self._generate_table_metadata(table_schema)
+        return self.create_out_table_definition(name=table_schema.csv_name,
+                                                columns=table_schema.field_names,
+                                                primary_key=table_schema.primary_keys,
+                                                table_metadata=table_metadata,
+                                                is_sliced=is_sliced,
+                                                destination=destination,
+                                                incremental=incremental,
+                                                enclosure=enclosure,
+                                                delimiter=delimiter,
+                                                delete_where=delete_where)
+
+    def _generate_table_metadata(self, table_schema: ts.TableSchema) -&gt; dao.TableMetadata:
+        &#34;&#34;&#34;
+            Generates a TableMetadata object for the table definition using a TableSchema object.
+
+        &#34;&#34;&#34;
+        table_metadata = dao.TableMetadata()
+        if table_schema.description:
+            table_metadata.add_table_description(table_schema.description)
+        table_metadata.add_column_descriptions({field.name: field.description for field in table_schema.fields})
+        table_metadata = self._add_field_data_types_to_table_metadata(table_schema, table_metadata)
+        return table_metadata
+
+    @staticmethod
+    def _add_field_data_types_to_table_metadata(table_schema: ts.TableSchema,
+                                                table_metadata: dao.TableMetadata) -&gt; dao.TableMetadata:
+        &#34;&#34;&#34;
+            Adds data types of all fields specified in a TableSchema object to a given TableMetadata object
+
+        &#34;&#34;&#34;
+        for field in table_schema.fields:
+            if field.base_type:
+                table_metadata.add_column_data_type(field.name,
+                                                    data_type=field.base_type,
+                                                    nullable=field.nullable,
+                                                    length=field.length,
+                                                    default=field.default)
+        return table_metadata</code></pre>
 </details>
 <h3>Ancestors</h3>
 <ul class="hlist">
@@ -309,6 +498,79 @@ def set_debug_mode():
 </dl>
 <h3>Methods</h3>
 <dl>
+<dt id="keboola.component.base.ComponentBase.create_out_table_definition_from_schema_name"><code class="name flex">
+<span>def <span class="ident">create_out_table_definition_from_schema_name</span></span>(<span>self, schema_name: str, is_sliced: bool = False, destination: str = '', incremental: bool = None, enclosure: str = '"', delimiter: str = ',', delete_where: dict = None) ‑> <a title="keboola.component.dao.TableDefinition" href="dao.html#keboola.component.dao.TableDefinition">TableDefinition</a></span>
+</code></dt>
+<dd>
+<div class="desc"><p>Creates an out table definition using a defined table schema.
+The method finds a given table schema based on a given name in a defined schema_folder_path and generates
+a TableSchema object. From this object, the table metadata is generated and used to populate the table
+definition.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt>schema_name : name of the schema in the schema_folder_path. e.g. for schema in 'schemas/output.json'</dt>
+<dt>schema_name is 'output'</dt>
+<dt><strong><code>is_sliced</code></strong></dt>
+<dd>True if the full_path points to a folder with sliced tables</dd>
+<dt><strong><code>destination</code></strong></dt>
+<dd>String name of the table in Storage.</dd>
+<dt><strong><code>incremental</code></strong></dt>
+<dd>Set to true to enable incremental loading</dd>
+<dt><strong><code>enclosure</code></strong></dt>
+<dd>str: CSV enclosure, by default "</dd>
+<dt><strong><code>delimiter</code></strong></dt>
+<dd>str: CSV delimiter, by default ,</dd>
+<dt><strong><code>delete_where</code></strong></dt>
+<dd>Dict with settings for deleting rows</dd>
+</dl>
+<h2 id="returns">Returns</h2>
+<p>TableDefinition object initialized with all table metadata defined in a schema</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def create_out_table_definition_from_schema_name(self, schema_name: str, is_sliced: bool = False,
+                                                 destination: str = &#39;&#39;, incremental: bool = None,
+                                                 enclosure: str = &#39;&#34;&#39;, delimiter: str = &#39;,&#39;,
+                                                 delete_where: dict = None) -&gt; dao.TableDefinition:
+    &#34;&#34;&#34;
+        Creates an out table definition using a defined table schema.
+        The method finds a given table schema based on a given name in a defined schema_folder_path and generates
+        a TableSchema object. From this object, the table metadata is generated and used to populate the table
+        definition.
+
+        Args:
+            schema_name : name of the schema in the schema_folder_path. e.g. for schema in &#39;schemas/output.json&#39;
+                          schema_name is &#39;output&#39;
+            is_sliced: True if the full_path points to a folder with sliced tables
+            destination: String name of the table in Storage.
+            incremental: Set to true to enable incremental loading
+            enclosure: str: CSV enclosure, by default &#34;
+            delimiter: str: CSV delimiter, by default ,
+            delete_where: Dict with settings for deleting rows
+
+        Returns:
+            TableDefinition object initialized with all table metadata defined in a schema
+
+    &#34;&#34;&#34;
+    if not self.schema_folder_path:
+        raise FileNotFoundError(&#34;A schema folder path must be defined in order to create a out table definition &#34;
+                                &#34;from a schema. If a schema folder path is not defined, the schemas folder must be &#34;
+                                &#34;located in the &#39;src&#39; directory of a component : src/schemas&#34;)
+    table_schema = ts.get_schema_by_name(schema_name, self.schema_folder_path)
+    table_metadata = self._generate_table_metadata(table_schema)
+    return self.create_out_table_definition(name=table_schema.csv_name,
+                                            columns=table_schema.field_names,
+                                            primary_key=table_schema.primary_keys,
+                                            table_metadata=table_metadata,
+                                            is_sliced=is_sliced,
+                                            destination=destination,
+                                            incremental=incremental,
+                                            enclosure=enclosure,
+                                            delimiter=delimiter,
+                                            delete_where=delete_where)</code></pre>
+</details>
+</dd>
 <dt id="keboola.component.base.ComponentBase.execute_action"><code class="name flex">
 <span>def <span class="ident">execute_action</span></span>(<span>self)</span>
 </code></dt>
@@ -403,6 +665,7 @@ def run(self):
 <li>
 <h4><code><a title="keboola.component.base.ComponentBase" href="#keboola.component.base.ComponentBase">ComponentBase</a></code></h4>
 <ul class="">
+<li><code><a title="keboola.component.base.ComponentBase.create_out_table_definition_from_schema_name" href="#keboola.component.base.ComponentBase.create_out_table_definition_from_schema_name">create_out_table_definition_from_schema_name</a></code></li>
 <li><code><a title="keboola.component.base.ComponentBase.execute_action" href="#keboola.component.base.ComponentBase.execute_action">execute_action</a></code></li>
 <li><code><a title="keboola.component.base.ComponentBase.run" href="#keboola.component.base.ComponentBase.run">run</a></code></li>
 <li><code><a title="keboola.component.base.ComponentBase.set_debug_mode" href="#keboola.component.base.ComponentBase.set_debug_mode">set_debug_mode</a></code></li>

--- a/docs/index.html
+++ b/docs/index.html
@@ -51,6 +51,10 @@ from .interface import CommonInterface, Configuration  # noqa F401
 <dd>
 <div class="desc"></div>
 </dd>
+<dt><code class="name"><a title="keboola.component.table_schema" href="table_schema.html">keboola.component.table_schema</a></code></dt>
+<dd>
+<div class="desc"></div>
+</dd>
 </dl>
 </section>
 <section>
@@ -72,6 +76,7 @@ from .interface import CommonInterface, Configuration  # noqa F401
 <li><code><a title="keboola.component.dao" href="dao.html">keboola.component.dao</a></code></li>
 <li><code><a title="keboola.component.exceptions" href="exceptions.html">keboola.component.exceptions</a></code></li>
 <li><code><a title="keboola.component.interface" href="interface.html">keboola.component.interface</a></code></li>
+<li><code><a title="keboola.component.table_schema" href="table_schema.html">keboola.component.table_schema</a></code></li>
 </ul>
 </li>
 </ul>

--- a/src/keboola/component/base.py
+++ b/src/keboola/component/base.py
@@ -1,7 +1,7 @@
 import logging
 import os
-import table_schema as ts
-import dao
+from . import dao
+from . import table_schema as ts
 from abc import ABC, abstractmethod
 from pathlib import Path
 from typing import Optional
@@ -91,7 +91,7 @@ class ComponentBase(ABC, CommonInterface):
         return schema_path_override or self._get_default_schema_folder_path()
 
     @staticmethod
-    def _get_default_schema_folder_path() -> str:
+    def _get_default_schema_folder_path() -> Optional[str]:
         """
              Finds the default schema_folder_path if it exists.
 
@@ -102,8 +102,6 @@ class ComponentBase(ABC, CommonInterface):
             return container_schema_dir
         elif os.path.isdir(local_schema_dir):
             return local_schema_dir
-        else:
-            raise FileNotFoundError("Could not find a directory containing schemas. Provide a valid directory.")
 
     @staticmethod
     def set_debug_mode():
@@ -163,7 +161,10 @@ class ComponentBase(ABC, CommonInterface):
                 TableDefinition object initialized with all table metadata defined in a schema
 
         """
-
+        if not self.schema_folder_path:
+            raise FileNotFoundError("A schema folder path must be defined in order to create a out table definition "
+                                    "from a schema. If a schema folder path is not defined, the schemas folder must be "
+                                    "located in the 'src' directory of a component : src/schemas")
         table_schema = ts.get_schema_by_name(schema_name, self.schema_folder_path)
         table_metadata = self._generate_table_metadata(table_schema)
         return self.create_out_table_definition(name=table_schema.csv_name,

--- a/src/keboola/component/base.py
+++ b/src/keboola/component/base.py
@@ -1,9 +1,10 @@
 import logging
 import os
+import table_schema as ts
+import dao
 from abc import ABC, abstractmethod
 from pathlib import Path
 from typing import Optional
-
 from .interface import CommonInterface
 
 KEY_DEBUG = 'debug'
@@ -11,6 +12,7 @@ KEY_DEBUG = 'debug'
 
 class ComponentBase(ABC, CommonInterface):
     def __init__(self, data_path_override: Optional[str] = None,
+                 schema_path_override: Optional[str] = None,
                  required_parameters: Optional[list] = None,
                  required_image_parameters: Optional[list] = None):
         """
@@ -47,7 +49,10 @@ class ComponentBase(ABC, CommonInterface):
         if self.configuration.parameters.get(KEY_DEBUG):
             self.set_debug_mode()
 
-    def _get_default_data_path(self) -> str:
+        self.schema_folder_path = self._get_schema_folder_path(schema_path_override)
+
+    @staticmethod
+    def _get_default_data_path() -> str:
         """
         Returns default data_path, by default `../data` is used, relative to working directory.
         This helps with local development.
@@ -76,6 +81,29 @@ class ComponentBase(ABC, CommonInterface):
         elif not os.environ.get('KBC_DATADIR'):
             data_folder_path = self._get_default_data_path()
         return data_folder_path
+
+    def _get_schema_folder_path(self, schema_path_override: str = None) -> str:
+        """
+            Returns value of the schema_folder_path in case the schema_path_override variable is provided or
+            the default schema_folder_path is found.
+
+        """
+        return schema_path_override or self._get_default_schema_folder_path()
+
+    @staticmethod
+    def _get_default_schema_folder_path() -> str:
+        """
+             Finds the default schema_folder_path if it exists.
+
+        """
+        container_schema_dir = Path("./src/schemas/").absolute().as_posix()
+        local_schema_dir = Path("./schemas").absolute().as_posix()
+        if os.path.isdir(container_schema_dir):
+            return container_schema_dir
+        elif os.path.isdir(local_schema_dir):
+            return local_schema_dir
+        else:
+            raise FileNotFoundError("Could not find a directory containing schemas. Provide a valid directory.")
 
     @staticmethod
     def set_debug_mode():
@@ -110,3 +138,69 @@ class ComponentBase(ABC, CommonInterface):
         except AttributeError as e:
             raise AttributeError(f"The defined action {action} is not implemented!") from e
         return action_method()
+
+    def create_out_table_definition_from_schema_name(self, schema_name: str, is_sliced: bool = False,
+                                                     destination: str = '', incremental: bool = None,
+                                                     enclosure: str = '"', delimiter: str = ',',
+                                                     delete_where: dict = None) -> dao.TableDefinition:
+        """
+            Creates an out table definition using a defined table schema.
+            The method finds a given table schema based on a given name in a defined schema_folder_path and generates
+            a TableSchema object. From this object, the table metadata is generated and used to populate the table
+            definition.
+
+            Args:
+                schema_name : name of the schema in the schema_folder_path. e.g. for schema in 'schemas/output.json'
+                              schema_name is 'output'
+                is_sliced: True if the full_path points to a folder with sliced tables
+                destination: String name of the table in Storage.
+                incremental: Set to true to enable incremental loading
+                enclosure: str: CSV enclosure, by default "
+                delimiter: str: CSV delimiter, by default ,
+                delete_where: Dict with settings for deleting rows
+
+            Returns:
+                TableDefinition object initialized with all table metadata defined in a schema
+
+        """
+
+        table_schema = ts.get_schema_by_name(schema_name, self.schema_folder_path)
+        table_metadata = self._generate_table_metadata(table_schema)
+        return self.create_out_table_definition(name=table_schema.csv_name,
+                                                columns=table_schema.field_names,
+                                                primary_key=table_schema.primary_keys,
+                                                table_metadata=table_metadata,
+                                                is_sliced=is_sliced,
+                                                destination=destination,
+                                                incremental=incremental,
+                                                enclosure=enclosure,
+                                                delimiter=delimiter,
+                                                delete_where=delete_where)
+
+    def _generate_table_metadata(self, table_schema: ts.TableSchema) -> dao.TableMetadata:
+        """
+            Generates a TableMetadata object for the table definition using a TableSchema object.
+
+        """
+        table_metadata = dao.TableMetadata()
+        if table_schema.description:
+            table_metadata.add_table_description(table_schema.description)
+        table_metadata.add_column_descriptions({field.name: field.description for field in table_schema.fields})
+        table_metadata = self._add_field_data_types_to_table_metadata(table_schema, table_metadata)
+        return table_metadata
+
+    @staticmethod
+    def _add_field_data_types_to_table_metadata(table_schema: ts.TableSchema,
+                                                table_metadata: dao.TableMetadata) -> dao.TableMetadata:
+        """
+            Adds data types of all fields specified in a TableSchema object to a given TableMetadata object
+
+        """
+        for field in table_schema.fields:
+            if field.base_type:
+                table_metadata.add_column_data_type(field.name,
+                                                    data_type=field.base_type,
+                                                    nullable=field.nullable,
+                                                    length=field.length,
+                                                    default=field.default)
+        return table_metadata

--- a/src/keboola/component/base.py
+++ b/src/keboola/component/base.py
@@ -163,8 +163,8 @@ class ComponentBase(ABC, CommonInterface):
         """
         if not self.schema_folder_path:
             raise FileNotFoundError("A schema folder path must be defined in order to create a out table definition "
-                                    "from a schema. If a schema folder path is not defined, the schemas folder must be "
-                                    "located in the 'src' directory of a component : src/schemas")
+                                    "from a schema. If a schema folder path is not defined, the schemas folder must be"
+                                    " located in the 'src' directory of a component : src/schemas")
         table_schema = ts.get_schema_by_name(schema_name, self.schema_folder_path)
         table_metadata = self._generate_table_metadata(table_schema)
         return self.create_out_table_definition(name=table_schema.csv_name,

--- a/src/keboola/component/interface.py
+++ b/src/keboola/component/interface.py
@@ -15,6 +15,7 @@ from pytz import utc
 
 from . import dao
 from .exceptions import UserException
+from .table_schema import TableSchema, SchemaInterface
 
 
 def register_csv_dialect():

--- a/src/keboola/component/interface.py
+++ b/src/keboola/component/interface.py
@@ -15,7 +15,6 @@ from pytz import utc
 
 from . import dao
 from .exceptions import UserException
-from .table_schema import TableSchema, SchemaInterface
 
 
 def register_csv_dialect():

--- a/src/keboola/component/table_schema.py
+++ b/src/keboola/component/table_schema.py
@@ -36,6 +36,15 @@ class TableSchema:
     def csv_name(self) -> str:
         return f"{self.name}.csv"
 
+    def add_field(self, new_field: FieldSchema) -> None:
+        """
+        Adds extra field to the tableschema.
+        Args:
+            new_field:  FieldSchema to add to the list of fields
+
+        """
+        self.fields.append(new_field)
+
 
 def init_table_schema_from_dict(json_table_schema: Dict) -> TableSchema:
     """

--- a/src/keboola/component/table_schema.py
+++ b/src/keboola/component/table_schema.py
@@ -1,8 +1,6 @@
 from typing import List, Dict
 from typing import Optional, Union
 from keboola.component.dao import SupportedDataTypes
-import os
-import json
 from dataclasses import dataclass
 
 
@@ -79,4 +77,3 @@ def init_table_schema_from_dict(json_table_schema: Dict) -> TableSchema:
         raise KeyError(
             f"When creating the table schema the definition of the table failed : {type_error}") from type_error
     return ts
-

--- a/src/keboola/component/table_schema.py
+++ b/src/keboola/component/table_schema.py
@@ -68,8 +68,17 @@ def _init_table_schema_from_dict(json_table_schema: Dict) -> TableSchema:
       ]
     }
     """
-    json_table_schema["fields"] = [FieldSchema(**field) for field in json_table_schema["fields"]]
-    return TableSchema(**json_table_schema)
+    try:
+        json_table_schema["fields"] = [FieldSchema(**field) for field in json_table_schema["fields"]]
+    except TypeError as type_error:
+        raise KeyError(
+            f"When creating the table schema the definition of columns failed : {type_error}") from type_error
+    try:
+        ts = TableSchema(**json_table_schema)
+    except TypeError as type_error:
+        raise KeyError(
+            f"When creating the table schema the definition of the table failed : {type_error}") from type_error
+    return ts
 
 
 def get_schema_by_name(schema_name: str, schema_folder_location: str) -> TableSchema:

--- a/src/keboola/component/table_schema.py
+++ b/src/keboola/component/table_schema.py
@@ -1,0 +1,84 @@
+from typing import List, Dict
+from typing import Optional, Union
+from keboola.component.dao import SupportedDataTypes
+import os
+import json
+from dataclasses import dataclass
+
+
+@dataclass
+class FieldSchema:
+    """
+    Defines the name and type specifications of a single field in a table
+    """
+    name: str
+    base_type: Optional[Union[SupportedDataTypes, str]] = None
+    description: Optional[str] = None
+    nullable: bool = False
+    length: Optional[str] = None
+    default: Optional[str] = None
+
+
+@dataclass
+class TableSchema:
+    """
+    TableSchema class is used to define the schema and metadata of a table.
+    """
+    name: str
+    fields: List[FieldSchema]
+    primary_keys: Optional[List[str]] = None
+    parent_tables: Optional[List[str]] = None
+    description: Optional[str] = None
+
+    @property
+    def field_names(self) -> List[str]:
+        return [column.name for column in self.fields]
+
+    @property
+    def csv_name(self) -> str:
+        return f"{self.name}.csv"
+
+
+def _init_table_schema_from_dict(json_table_schema: Dict) -> TableSchema:
+    """
+    Function to initialize a Table Schema from a dictionary.
+    Example of the json_table_schema structure:
+    {
+      "name": "product",
+      "description": "this table holds data on products",
+      "parent_tables": [],
+      "primary_keys": [
+        "id"
+      ],
+      "fields": [
+        {
+          "name": "id",
+          "base_type": "string",
+          "description": "ID of the product",
+          "length": "100",
+          "nullable": false
+        },
+        {
+          "name": "name",
+          "base_type": "string",
+          "description": "Plain-text name of the product",
+          "length": "1000",
+          "default": "Default Name"
+        }
+      ]
+    }
+    """
+    json_table_schema["fields"] = [FieldSchema(**field) for field in json_table_schema["fields"]]
+    return TableSchema(**json_table_schema)
+
+
+def get_schema_by_name(schema_name: str, schema_folder_location: str) -> TableSchema:
+    try:
+        with open(os.path.join(schema_folder_location, f"{schema_name}.json"), 'r') as schema_file:
+            json_schema = json.loads(schema_file.read())
+    except FileNotFoundError as file_err:
+        raise FileNotFoundError(
+            f"Schema for corresponding schema name : {schema_name} is not found in the schema directory. "
+            f"Make sure that '{schema_name}'.json "
+            f"exists in the directory '{schema_folder_location}'") from file_err
+    return _init_table_schema_from_dict(json_schema)

--- a/src/keboola/component/table_schema.py
+++ b/src/keboola/component/table_schema.py
@@ -39,7 +39,7 @@ class TableSchema:
         return f"{self.name}.csv"
 
 
-def _init_table_schema_from_dict(json_table_schema: Dict) -> TableSchema:
+def init_table_schema_from_dict(json_table_schema: Dict) -> TableSchema:
     """
     Function to initialize a Table Schema from a dictionary.
     Example of the json_table_schema structure:
@@ -80,14 +80,3 @@ def _init_table_schema_from_dict(json_table_schema: Dict) -> TableSchema:
             f"When creating the table schema the definition of the table failed : {type_error}") from type_error
     return ts
 
-
-def get_schema_by_name(schema_name: str, schema_folder_location: str) -> TableSchema:
-    try:
-        with open(os.path.join(schema_folder_location, f"{schema_name}.json"), 'r') as schema_file:
-            json_schema = json.loads(schema_file.read())
-    except FileNotFoundError as file_err:
-        raise FileNotFoundError(
-            f"Schema for corresponding schema name : {schema_name} is not found in the schema directory. "
-            f"Make sure that '{schema_name}'.json "
-            f"exists in the directory '{schema_folder_location}'") from file_err
-    return _init_table_schema_from_dict(json_schema)

--- a/tests/schema_examples/faulty-schemas/invalid_base_type.json
+++ b/tests/schema_examples/faulty-schemas/invalid_base_type.json
@@ -1,0 +1,26 @@
+{
+  "name": "order",
+  "description": "this table holds data on orders",
+  "parent_tables": [],
+  "primary_keys": [
+    "id"
+  ],
+  "fields": [
+    {
+      "name": "id",
+      "base_type": "PIVO & PAREK",
+      "description": "ID of the order",
+      "nullable": false
+    },
+    {
+      "name": "product_id",
+      "base_type": "STRING",
+      "description": "Id of the product in order"
+    },
+    {
+      "name": "quantity",
+      "base_type": "STRING",
+      "description": "Quantity of the product in order"
+    }
+  ]
+}

--- a/tests/schema_examples/faulty-schemas/invalid_column_schema.json
+++ b/tests/schema_examples/faulty-schemas/invalid_column_schema.json
@@ -1,0 +1,22 @@
+{
+  "name": "product",
+  "description": "this table holds data on products",
+  "parent_tables": [],
+  "primary_keys": [
+    "id"
+  ],
+  "fields": [
+    {
+      "name": "id",
+      "description": "ID of the product",
+      "some-invalid-key": "hi"
+    },
+    {
+      "name": "name",
+      "base_type": "STRING",
+      "description": "Plain-text name of the product",
+      "length": "1000",
+      "default": "Default Name"
+    }
+  ]
+}

--- a/tests/schema_examples/faulty-schemas/invalid_table_schema.json
+++ b/tests/schema_examples/faulty-schemas/invalid_table_schema.json
@@ -1,0 +1,27 @@
+{
+  "name": "order",
+  "description": "this table holds data on orders",
+  "parent_tables": [],
+  "some_extra" : "here",
+  "primary_keys": [
+    "id"
+  ],
+  "fields": [
+    {
+      "name": "id",
+      "base_type": "STRING",
+      "description": "ID of the order",
+      "nullable": false
+    },
+    {
+      "name": "product_id",
+      "base_type": "STRING",
+      "description": "Id of the product in order"
+    },
+    {
+      "name": "quantity",
+      "base_type": "STRING",
+      "description": "Quantity of the product in order"
+    }
+  ]
+}

--- a/tests/schema_examples/schemas/order.json
+++ b/tests/schema_examples/schemas/order.json
@@ -1,0 +1,26 @@
+{
+  "name": "order",
+  "description": "this table holds data on orders",
+  "parent_tables": [],
+  "primary_keys": [
+    "id"
+  ],
+  "fields": [
+    {
+      "name": "id",
+      "base_type": "STRING",
+      "description": "ID of the order",
+      "nullable": false
+    },
+    {
+      "name": "product_id",
+      "base_type": "STRING",
+      "description": "Id of the product in order"
+    },
+    {
+      "name": "quantity",
+      "base_type": "STRING",
+      "description": "Quantity of the product in order"
+    }
+  ]
+}

--- a/tests/schema_examples/schemas/product.json
+++ b/tests/schema_examples/schemas/product.json
@@ -1,0 +1,21 @@
+{
+  "name": "product",
+  "description": "this table holds data on products",
+  "parent_tables": [],
+  "primary_keys": [
+    "id"
+  ],
+  "fields": [
+    {
+      "name": "id",
+      "description": "ID of the product"
+    },
+    {
+      "name": "name",
+      "base_type": "STRING",
+      "description": "Plain-text name of the product",
+      "length": "1000",
+      "default": "Default Name"
+    }
+  ]
+}

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -18,7 +18,8 @@ class TestCommonInterface(unittest.TestCase):
     def test_create_out_table_definition_from_schema_name(self):
         schema_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'schema_examples', 'schemas')
         comp = MockComponent(schema_path_override=schema_path)
-        order_table_definition_from_schema = comp.create_out_table_definition_from_schema_name(schema_name="order")
+        order_schema = comp.get_table_schema_by_name(schema_name="order")
+        order_table_definition_from_schema = comp.create_out_table_definition_from_schema(order_schema)
         self.assertEqual("order.csv", order_table_definition_from_schema.name)
         self.assertEqual(["id", "product_id", "quantity"], order_table_definition_from_schema.columns)
         self.assertEqual(["id"], order_table_definition_from_schema.primary_key)
@@ -26,7 +27,8 @@ class TestCommonInterface(unittest.TestCase):
     def test_created_manifest_against_schema(self):
         schema_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'schema_examples', 'schemas')
         comp = MockComponent(schema_path_override=schema_path)
-        order_table_definition_from_schema = comp.create_out_table_definition_from_schema_name(schema_name="order")
+        order_schema = comp.get_table_schema_by_name(schema_name="order")
+        order_table_definition_from_schema = comp.create_out_table_definition_from_schema(order_schema)
         manifest_dict = order_table_definition_from_schema.get_manifest_dictionary()
         expected_manifest = {'primary_key': ['id'], 'columns': ['id', 'product_id', 'quantity'], 'enclosure': '"',
                              'delimiter': ',',
@@ -49,31 +51,36 @@ class TestCommonInterface(unittest.TestCase):
         with self.assertRaises(KeyError):
             schema_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'schema_examples', 'faulty-schemas')
             comp = MockComponent(schema_path_override=schema_path)
-            comp.create_out_table_definition_from_schema_name(schema_name="invalid_column_schema")
+            table_schema = comp.get_table_schema_by_name(schema_name="invalid_column_schema")
+            comp.create_out_table_definition_from_schema(table_schema)
 
     def test_invalid_schema_raises_key_error(self):
         with self.assertRaises(KeyError):
             schema_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'schema_examples', 'faulty-schemas')
             comp = MockComponent(schema_path_override=schema_path)
-            comp.create_out_table_definition_from_schema_name(schema_name="invalid_table_schema")
+            table_schema = comp.get_table_schema_by_name(schema_name="invalid_table_schema")
+            comp.create_out_table_definition_from_schema(table_schema)
 
     def test_missing_schema_raises_key_error(self):
         with self.assertRaises(FileNotFoundError):
             schema_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'schema_examples', 'faulty-schemas')
             comp = MockComponent(schema_path_override=schema_path)
-            comp.create_out_table_definition_from_schema_name(schema_name="missing")
+            table_schema = comp.get_table_schema_by_name(schema_name="missing")
+            comp.create_out_table_definition_from_schema(table_schema)
 
     def test_invalid_schema_path_raises_key_error(self):
         with self.assertRaises(FileNotFoundError):
             schema_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'schema_examples', 'missing')
             comp = MockComponent(schema_path_override=schema_path)
-            comp.create_out_table_definition_from_schema_name(schema_name="missing")
+            table_schema = comp.get_table_schema_by_name(schema_name="missing")
+            comp.create_out_table_definition_from_schema(table_schema)
 
     def test_invalid_base_type_raises_key_error(self):
         with self.assertRaises(ValueError):
             schema_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'schema_examples', 'faulty-schemas')
             comp = MockComponent(schema_path_override=schema_path)
-            comp.create_out_table_definition_from_schema_name(schema_name="invalid_base_type")
+            table_schema = comp.get_table_schema_by_name(schema_name="invalid_base_type")
+            comp.create_out_table_definition_from_schema(table_schema)
 
 
 if __name__ == '__main__':

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1,0 +1,80 @@
+import os
+import unittest
+
+from keboola.component.base import ComponentBase
+
+
+class MockComponent(ComponentBase):
+    def run(self):
+        return 'run_executed'
+
+
+class TestCommonInterface(unittest.TestCase):
+
+    def setUp(self):
+        path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data_examples', 'data1')
+        os.environ["KBC_DATADIR"] = path
+
+    def test_create_out_table_definition_from_schema_name(self):
+        schema_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'schema_examples', 'schemas')
+        comp = MockComponent(schema_path_override=schema_path)
+        order_table_definition_from_schema = comp.create_out_table_definition_from_schema_name(schema_name="order")
+        self.assertEqual("order.csv", order_table_definition_from_schema.name)
+        self.assertEqual(["id", "product_id", "quantity"], order_table_definition_from_schema.columns)
+        self.assertEqual(["id"], order_table_definition_from_schema.primary_key)
+
+    def test_created_manifest_against_schema(self):
+        schema_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'schema_examples', 'schemas')
+        comp = MockComponent(schema_path_override=schema_path)
+        order_table_definition_from_schema = comp.create_out_table_definition_from_schema_name(schema_name="order")
+        manifest_dict = order_table_definition_from_schema.get_manifest_dictionary()
+        expected_manifest = {'primary_key': ['id'], 'columns': ['id', 'product_id', 'quantity'], 'enclosure': '"',
+                             'delimiter': ',',
+                             'metadata': [{'key': 'KBC.description', 'value': 'this table holds data on orders'}],
+                             'column_metadata': {'id': [{'key': 'KBC.description', 'value': 'ID of the order'},
+                                                        {'key': 'KBC.datatype.basetype', 'value': 'STRING'},
+                                                        {'key': 'KBC.datatype.nullable', 'value': False}],
+                                                 'product_id': [
+                                                     {'key': 'KBC.description', 'value': 'Id of the product in order'},
+                                                     {'key': 'KBC.datatype.basetype', 'value': 'STRING'},
+                                                     {'key': 'KBC.datatype.nullable', 'value': False}],
+                                                 'quantity': [
+                                                     {'key': 'KBC.description',
+                                                      'value': 'Quantity of the product in order'},
+                                                     {'key': 'KBC.datatype.basetype', 'value': 'STRING'},
+                                                     {'key': 'KBC.datatype.nullable', 'value': False}]}}
+        self.assertEqual(manifest_dict, expected_manifest)
+
+    def test_invalid_column_schema_raises_key_error(self):
+        with self.assertRaises(KeyError):
+            schema_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'schema_examples', 'faulty-schemas')
+            comp = MockComponent(schema_path_override=schema_path)
+            comp.create_out_table_definition_from_schema_name(schema_name="invalid_column_schema")
+
+    def test_invalid_schema_raises_key_error(self):
+        with self.assertRaises(KeyError):
+            schema_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'schema_examples', 'faulty-schemas')
+            comp = MockComponent(schema_path_override=schema_path)
+            comp.create_out_table_definition_from_schema_name(schema_name="invalid_table_schema")
+
+    def test_missing_schema_raises_key_error(self):
+        with self.assertRaises(FileNotFoundError):
+            schema_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'schema_examples', 'faulty-schemas')
+            comp = MockComponent(schema_path_override=schema_path)
+            comp.create_out_table_definition_from_schema_name(schema_name="missing")
+
+    def test_invalid_schema_path_raises_key_error(self):
+        with self.assertRaises(FileNotFoundError):
+            schema_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'schema_examples', 'missing')
+            comp = MockComponent(schema_path_override=schema_path)
+            comp.create_out_table_definition_from_schema_name(schema_name="missing")
+
+    def test_invalid_base_type_raises_key_error(self):
+        with self.assertRaises(ValueError):
+            schema_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'schema_examples', 'faulty-schemas')
+            comp = MockComponent(schema_path_override=schema_path)
+            comp.create_out_table_definition_from_schema_name(schema_name="invalid_base_type")
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This addition to the lib is needed so we can more easily define output table schemas with extractors that have a prededined output schema.  Later it can also be utilized to validate the inputs for writers and applications using the input metadata vs set schema.