### PR TITLE
Fix backward compatibility with list/dict elements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ project_urls = {
 
 setuptools.setup(
     name="keboola.component",
-    version="1.4.2",
+    version="1.4.3",
     author="Keboola KDS Team",
     project_urls=project_urls,
     setup_requires=['pytest-runner', 'flake8'],

--- a/src/keboola/component/sync_actions.py
+++ b/src/keboola/component/sync_actions.py
@@ -63,7 +63,7 @@ class SelectElement(SyncActionResult):
         self.status = None
 
 
-def process_sync_action_result(result: Union[None, dict, SyncActionResult, List[SyncActionResult]]) -> str:
+def process_sync_action_result(result: Union[None, List[dict], dict, SyncActionResult, List[SyncActionResult]]) -> str:
     """
     Converts Sync Action result into valid string (expected by Sync Action).
     Args:
@@ -75,7 +75,7 @@ def process_sync_action_result(result: Union[None, dict, SyncActionResult, List[
     if isinstance(result, SyncActionResult):
         result_str = str(result)
     elif isinstance(result, list):
-        result_str = f'[{", ".join([str(r) for r in result])}]'
+        result_str = f'[{", ".join([json.dumps(r) for r in result])}]'
     elif result is None:
         result_str = json.dumps({'status': 'success'})
     elif isinstance(result, dict):

--- a/tests/test_sync_actions.py
+++ b/tests/test_sync_actions.py
@@ -11,6 +11,12 @@ class TestSyncActions(unittest.TestCase):
         expected = '[{"value": "value_a", "label": "label_a"}, {"value": "value_b", "label": "value_b"}]'
         self.assertEqual(process_sync_action_result(select_options), expected)
 
+    def test_select_element_return_value_legacy(self):
+        select_options = [dict(value="value_a", label="label_a"),
+                          dict(value="value_b", label="value_b")]
+        expected = '[{"value": "value_a", "label": "label_a"}, {"value": "value_b", "label": "value_b"}]'
+        self.assertEqual(process_sync_action_result(select_options), expected)
+
     def test_validation_result_value(self):
         result = ValidationResult("Some Message", MessageType.WARNING)
         expected = '{"message": "Some Message", "type": "warning", "status": "success"}'


### PR DESCRIPTION
So current implementations using `[{"label":"ss","value":"ccc"}]` syntax will continue working