### PR TITLE
Feture/write always

### DIFF
--- a/docs/dao.html
+++ b/docs/dao.html
@@ -615,6 +615,7 @@ class TableDefinition(IODefinition):
         &#34;columns&#34;,
         &#34;incremental&#34;,
         &#34;primary_key&#34;,
+        &#34;write_always&#34;,
         &#34;delimiter&#34;,
         &#34;enclosure&#34;,
         &#34;metadata&#34;,
@@ -636,7 +637,9 @@ class TableDefinition(IODefinition):
                  enclosure: str = &#39;&#34;&#39;,
                  delimiter: str = &#39;,&#39;,
                  delete_where: dict = None,
-                 stage: str = &#39;in&#39;):
+                 stage: str = &#39;in&#39;,
+                 write_always: bool = False
+                 ):
         &#34;&#34;&#34;
 
         Args:
@@ -658,6 +661,8 @@ class TableDefinition(IODefinition):
             delimiter: str: CSV delimiter, by default ,
             delete_where (dict): Dict with settings for deleting rows
             stage: str: Storage Stage &#39;in&#39; or &#39;out&#39;
+            write_always: Bool: If true, the table will be saved to Storage even when the job execution
+                           fails.
         &#34;&#34;&#34;
         super().__init__(full_path)
         self._name = name
@@ -678,6 +683,7 @@ class TableDefinition(IODefinition):
         self.table_metadata = table_metadata
         self.set_delete_where_from_dict(delete_where)
         self.stage = stage
+        self.write_always = write_always
 
     @classmethod
     def build_from_manifest(cls,
@@ -824,6 +830,15 @@ class TableDefinition(IODefinition):
     def incremental(self, incremental: bool):
         if incremental:
             self._raw_manifest[&#39;incremental&#39;] = True
+
+    @property
+    def write_always(self) -&gt; bool:
+        return self._raw_manifest.get(&#39;write_always&#39;, False)
+
+    @write_always.setter
+    def write_always(self, incremental: bool):
+        if incremental:
+            self._raw_manifest[&#39;write_always&#39;] = True
 
     @property
     def primary_key(self) -&gt; List[str]:
@@ -2676,7 +2691,7 @@ class TableColumnTypes(SubscriptableDataclass):
 </dd>
 <dt id="keboola.component.dao.TableDefinition"><code class="flex name class">
 <span>class <span class="ident">TableDefinition</span></span>
-<span>(</span><span>name: str, full_path: Optional[str] = None, is_sliced: bool = False, destination: str = '', primary_key: List[str] = None, columns: List[str] = None, incremental: bool = None, table_metadata: <a title="keboola.component.dao.TableMetadata" href="#keboola.component.dao.TableMetadata">TableMetadata</a> = None, enclosure: str = '"', delimiter: str = ',', delete_where: dict = None, stage: str = 'in')</span>
+<span>(</span><span>name: str, full_path: Optional[str] = None, is_sliced: bool = False, destination: str = '', primary_key: List[str] = None, columns: List[str] = None, incremental: bool = None, table_metadata: <a title="keboola.component.dao.TableMetadata" href="#keboola.component.dao.TableMetadata">TableMetadata</a> = None, enclosure: str = '"', delimiter: str = ',', delete_where: dict = None, stage: str = 'in', write_always: bool = False)</span>
 </code></dt>
 <dd>
 <div class="desc"><p>Table definition class. It is used as a container for <code>in/tables/</code> files.
@@ -2748,6 +2763,9 @@ The full_path is None when dealing with <a href="https://developers.keboola.com/
 <dd>Dict with settings for deleting rows</dd>
 <dt><strong><code>stage</code></strong></dt>
 <dd>str: Storage Stage 'in' or 'out'</dd>
+<dt><strong><code>write_always</code></strong></dt>
+<dd>Bool: If true, the table will be saved to Storage even when the job execution
+fails.</dd>
 </dl></div>
 <details class="source">
 <summary>
@@ -2810,6 +2828,7 @@ The full_path is None when dealing with <a href="https://developers.keboola.com/
         &#34;columns&#34;,
         &#34;incremental&#34;,
         &#34;primary_key&#34;,
+        &#34;write_always&#34;,
         &#34;delimiter&#34;,
         &#34;enclosure&#34;,
         &#34;metadata&#34;,
@@ -2831,7 +2850,9 @@ The full_path is None when dealing with <a href="https://developers.keboola.com/
                  enclosure: str = &#39;&#34;&#39;,
                  delimiter: str = &#39;,&#39;,
                  delete_where: dict = None,
-                 stage: str = &#39;in&#39;):
+                 stage: str = &#39;in&#39;,
+                 write_always: bool = False
+                 ):
         &#34;&#34;&#34;
 
         Args:
@@ -2853,6 +2874,8 @@ The full_path is None when dealing with <a href="https://developers.keboola.com/
             delimiter: str: CSV delimiter, by default ,
             delete_where (dict): Dict with settings for deleting rows
             stage: str: Storage Stage &#39;in&#39; or &#39;out&#39;
+            write_always: Bool: If true, the table will be saved to Storage even when the job execution
+                           fails.
         &#34;&#34;&#34;
         super().__init__(full_path)
         self._name = name
@@ -2873,6 +2896,7 @@ The full_path is None when dealing with <a href="https://developers.keboola.com/
         self.table_metadata = table_metadata
         self.set_delete_where_from_dict(delete_where)
         self.stage = stage
+        self.write_always = write_always
 
     @classmethod
     def build_from_manifest(cls,
@@ -3019,6 +3043,15 @@ The full_path is None when dealing with <a href="https://developers.keboola.com/
     def incremental(self, incremental: bool):
         if incremental:
             self._raw_manifest[&#39;incremental&#39;] = True
+
+    @property
+    def write_always(self) -&gt; bool:
+        return self._raw_manifest.get(&#39;write_always&#39;, False)
+
+    @write_always.setter
+    def write_always(self, incremental: bool):
+        if incremental:
+            self._raw_manifest[&#39;write_always&#39;] = True
 
     @property
     def primary_key(self) -&gt; List[str]:
@@ -3330,6 +3363,18 @@ def rows_count(self) -&gt; int:
 <pre><code class="python">@property
 def table_metadata(self) -&gt; TableMetadata:
     return self._table_metadata</code></pre>
+</details>
+</dd>
+<dt id="keboola.component.dao.TableDefinition.write_always"><code class="name">var <span class="ident">write_always</span> : bool</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">@property
+def write_always(self) -&gt; bool:
+    return self._raw_manifest.get(&#39;write_always&#39;, False)</code></pre>
 </details>
 </dd>
 </dl>
@@ -4513,6 +4558,7 @@ class TableOutputMapping(SubscriptableDataclass):
 <li><code><a title="keboola.component.dao.TableDefinition.rows_count" href="#keboola.component.dao.TableDefinition.rows_count">rows_count</a></code></li>
 <li><code><a title="keboola.component.dao.TableDefinition.set_delete_where_from_dict" href="#keboola.component.dao.TableDefinition.set_delete_where_from_dict">set_delete_where_from_dict</a></code></li>
 <li><code><a title="keboola.component.dao.TableDefinition.table_metadata" href="#keboola.component.dao.TableDefinition.table_metadata">table_metadata</a></code></li>
+<li><code><a title="keboola.component.dao.TableDefinition.write_always" href="#keboola.component.dao.TableDefinition.write_always">write_always</a></code></li>
 </ul>
 </li>
 <li>

--- a/docs/interface.html
+++ b/docs/interface.html
@@ -355,7 +355,8 @@ class CommonInterface:
                                  table_metadata: dao.TableMetadata = None,
                                  enclosure: str = &#39;&#34;&#39;,
                                  delimiter: str = &#39;,&#39;,
-                                 delete_where: dict = None) -&gt; dao.TableDefinition:
+                                 delete_where: dict = None,
+                                 write_always: bool = False) -&gt; dao.TableDefinition:
         &#34;&#34;&#34;
                 Helper method for dao.TableDefinition creation along with the &#34;manifest&#34;.
                 It initializes path according to the storage_stage type.
@@ -375,6 +376,8 @@ class CommonInterface:
                     enclosure: str: CSV enclosure, by default &#34;
                     delimiter: str: CSV delimiter, by default ,
                     delete_where: Dict with settings for deleting rows
+                    write_always: Bool: If true, the table will be saved to Storage even when the job execution
+                           fails.
         &#34;&#34;&#34;
         if storage_stage == &#39;in&#39;:
             full_path = os.path.join(self.tables_in_path, name)
@@ -394,7 +397,8 @@ class CommonInterface:
                                    enclosure=enclosure,
                                    delimiter=delimiter,
                                    delete_where=delete_where,
-                                   stage=storage_stage)
+                                   stage=storage_stage,
+                                   write_always=write_always)
 
     def create_in_table_definition(self, name: str,
                                    is_sliced: bool = False,
@@ -438,7 +442,8 @@ class CommonInterface:
                                     table_metadata: dao.TableMetadata = None,
                                     enclosure: str = &#39;&#34;&#39;,
                                     delimiter: str = &#39;,&#39;,
-                                    delete_where: dict = None) -&gt; dao.TableDefinition:
+                                    delete_where: dict = None,
+                                    write_always: bool = False) -&gt; dao.TableDefinition:
         &#34;&#34;&#34;
                        Helper method for output dao.TableDefinition creation along with the &#34;manifest&#34;.
                        It initializes path in data/tables/out/ folder.
@@ -454,6 +459,8 @@ class CommonInterface:
                            enclosure: str: CSV enclosure, by default &#34;
                            delimiter: str: CSV delimiter, by default ,
                            delete_where: Dict with settings for deleting rows
+                           write_always: Bool: If true, the table will be saved to Storage even when the job execution
+                           fails.
         &#34;&#34;&#34;
 
         return self._create_table_definition(name=name,
@@ -466,7 +473,8 @@ class CommonInterface:
                                              table_metadata=table_metadata,
                                              enclosure=enclosure,
                                              delimiter=delimiter,
-                                             delete_where=delete_where)
+                                             delete_where=delete_where,
+                                             write_always=write_always)
 
     # # File processing
 
@@ -1547,7 +1555,8 @@ is established in following order:</p>
                                  table_metadata: dao.TableMetadata = None,
                                  enclosure: str = &#39;&#34;&#39;,
                                  delimiter: str = &#39;,&#39;,
-                                 delete_where: dict = None) -&gt; dao.TableDefinition:
+                                 delete_where: dict = None,
+                                 write_always: bool = False) -&gt; dao.TableDefinition:
         &#34;&#34;&#34;
                 Helper method for dao.TableDefinition creation along with the &#34;manifest&#34;.
                 It initializes path according to the storage_stage type.
@@ -1567,6 +1576,8 @@ is established in following order:</p>
                     enclosure: str: CSV enclosure, by default &#34;
                     delimiter: str: CSV delimiter, by default ,
                     delete_where: Dict with settings for deleting rows
+                    write_always: Bool: If true, the table will be saved to Storage even when the job execution
+                           fails.
         &#34;&#34;&#34;
         if storage_stage == &#39;in&#39;:
             full_path = os.path.join(self.tables_in_path, name)
@@ -1586,7 +1597,8 @@ is established in following order:</p>
                                    enclosure=enclosure,
                                    delimiter=delimiter,
                                    delete_where=delete_where,
-                                   stage=storage_stage)
+                                   stage=storage_stage,
+                                   write_always=write_always)
 
     def create_in_table_definition(self, name: str,
                                    is_sliced: bool = False,
@@ -1630,7 +1642,8 @@ is established in following order:</p>
                                     table_metadata: dao.TableMetadata = None,
                                     enclosure: str = &#39;&#34;&#39;,
                                     delimiter: str = &#39;,&#39;,
-                                    delete_where: dict = None) -&gt; dao.TableDefinition:
+                                    delete_where: dict = None,
+                                    write_always: bool = False) -&gt; dao.TableDefinition:
         &#34;&#34;&#34;
                        Helper method for output dao.TableDefinition creation along with the &#34;manifest&#34;.
                        It initializes path in data/tables/out/ folder.
@@ -1646,6 +1659,8 @@ is established in following order:</p>
                            enclosure: str: CSV enclosure, by default &#34;
                            delimiter: str: CSV delimiter, by default ,
                            delete_where: Dict with settings for deleting rows
+                           write_always: Bool: If true, the table will be saved to Storage even when the job execution
+                           fails.
         &#34;&#34;&#34;
 
         return self._create_table_definition(name=name,
@@ -1658,7 +1673,8 @@ is established in following order:</p>
                                              table_metadata=table_metadata,
                                              enclosure=enclosure,
                                              delimiter=delimiter,
-                                             delete_where=delete_where)
+                                             delete_where=delete_where,
+                                             write_always=write_always)
 
     # # File processing
 
@@ -2813,7 +2829,7 @@ It initializes path in data/files/out/ folder.</p>
 </details>
 </dd>
 <dt id="keboola.component.interface.CommonInterface.create_out_table_definition"><code class="name flex">
-<span>def <span class="ident">create_out_table_definition</span></span>(<span>self, name: str, is_sliced: bool = False, destination: str = '', primary_key: List[str] = None, columns: List[str] = None, incremental: bool = None, table_metadata: <a title="keboola.component.dao.TableMetadata" href="dao.html#keboola.component.dao.TableMetadata">TableMetadata</a> = None, enclosure: str = '"', delimiter: str = ',', delete_where: dict = None) ‑> <a title="keboola.component.dao.TableDefinition" href="dao.html#keboola.component.dao.TableDefinition">TableDefinition</a></span>
+<span>def <span class="ident">create_out_table_definition</span></span>(<span>self, name: str, is_sliced: bool = False, destination: str = '', primary_key: List[str] = None, columns: List[str] = None, incremental: bool = None, table_metadata: <a title="keboola.component.dao.TableMetadata" href="dao.html#keboola.component.dao.TableMetadata">TableMetadata</a> = None, enclosure: str = '"', delimiter: str = ',', delete_where: dict = None, write_always: bool = False) ‑> <a title="keboola.component.dao.TableDefinition" href="dao.html#keboola.component.dao.TableDefinition">TableDefinition</a></span>
 </code></dt>
 <dd>
 <div class="desc"><p>Helper method for output dao.TableDefinition creation along with the "manifest".
@@ -2840,7 +2856,10 @@ It initializes path in data/tables/out/ folder.</p>
 <dd>str: CSV delimiter, by default ,</dd>
 <dt><strong><code>delete_where</code></strong></dt>
 <dd>Dict with settings for deleting rows</dd>
-</dl></div>
+<dt><strong><code>write_always</code></strong></dt>
+<dd>Bool: If true, the table will be saved to Storage even when the job execution</dd>
+</dl>
+<p>fails.</p></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
@@ -2854,7 +2873,8 @@ It initializes path in data/tables/out/ folder.</p>
                                 table_metadata: dao.TableMetadata = None,
                                 enclosure: str = &#39;&#34;&#39;,
                                 delimiter: str = &#39;,&#39;,
-                                delete_where: dict = None) -&gt; dao.TableDefinition:
+                                delete_where: dict = None,
+                                write_always: bool = False) -&gt; dao.TableDefinition:
     &#34;&#34;&#34;
                    Helper method for output dao.TableDefinition creation along with the &#34;manifest&#34;.
                    It initializes path in data/tables/out/ folder.
@@ -2870,6 +2890,8 @@ It initializes path in data/tables/out/ folder.</p>
                        enclosure: str: CSV enclosure, by default &#34;
                        delimiter: str: CSV delimiter, by default ,
                        delete_where: Dict with settings for deleting rows
+                       write_always: Bool: If true, the table will be saved to Storage even when the job execution
+                       fails.
     &#34;&#34;&#34;
 
     return self._create_table_definition(name=name,
@@ -2882,7 +2904,8 @@ It initializes path in data/tables/out/ folder.</p>
                                          table_metadata=table_metadata,
                                          enclosure=enclosure,
                                          delimiter=delimiter,
-                                         delete_where=delete_where)</code></pre>
+                                         delete_where=delete_where,
+                                         write_always=write_always)</code></pre>
 </details>
 </dd>
 <dt id="keboola.component.interface.CommonInterface.get_input_file_definitions_grouped_by_name"><code class="name flex">

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ project_urls = {
 
 setuptools.setup(
     name="keboola.component",
-    version="1.4.3",
+    version="1.4.4",
     author="Keboola KDS Team",
     project_urls=project_urls,
     setup_requires=['pytest-runner', 'flake8'],

--- a/src/keboola/component/dao.py
+++ b/src/keboola/component/dao.py
@@ -587,6 +587,7 @@ class TableDefinition(IODefinition):
         "columns",
         "incremental",
         "primary_key",
+        "write_always",
         "delimiter",
         "enclosure",
         "metadata",
@@ -608,7 +609,9 @@ class TableDefinition(IODefinition):
                  enclosure: str = '"',
                  delimiter: str = ',',
                  delete_where: dict = None,
-                 stage: str = 'in'):
+                 stage: str = 'in',
+                 write_always: bool = False
+                 ):
         """
 
         Args:
@@ -630,6 +633,8 @@ class TableDefinition(IODefinition):
             delimiter: str: CSV delimiter, by default ,
             delete_where (dict): Dict with settings for deleting rows
             stage: str: Storage Stage 'in' or 'out'
+            write_always: Bool: If true, the table will be saved to Storage even when the job execution
+                           fails.
         """
         super().__init__(full_path)
         self._name = name
@@ -650,6 +655,7 @@ class TableDefinition(IODefinition):
         self.table_metadata = table_metadata
         self.set_delete_where_from_dict(delete_where)
         self.stage = stage
+        self.write_always = write_always
 
     @classmethod
     def build_from_manifest(cls,
@@ -796,6 +802,15 @@ class TableDefinition(IODefinition):
     def incremental(self, incremental: bool):
         if incremental:
             self._raw_manifest['incremental'] = True
+
+    @property
+    def write_always(self) -> bool:
+        return self._raw_manifest.get('write_always', False)
+
+    @write_always.setter
+    def write_always(self, incremental: bool):
+        if incremental:
+            self._raw_manifest['write_always'] = True
 
     @property
     def primary_key(self) -> List[str]:

--- a/src/keboola/component/interface.py
+++ b/src/keboola/component/interface.py
@@ -327,7 +327,8 @@ class CommonInterface:
                                  table_metadata: dao.TableMetadata = None,
                                  enclosure: str = '"',
                                  delimiter: str = ',',
-                                 delete_where: dict = None) -> dao.TableDefinition:
+                                 delete_where: dict = None,
+                                 write_always: bool = False) -> dao.TableDefinition:
         """
                 Helper method for dao.TableDefinition creation along with the "manifest".
                 It initializes path according to the storage_stage type.
@@ -347,6 +348,8 @@ class CommonInterface:
                     enclosure: str: CSV enclosure, by default "
                     delimiter: str: CSV delimiter, by default ,
                     delete_where: Dict with settings for deleting rows
+                    write_always: Bool: If true, the table will be saved to Storage even when the job execution
+                           fails.
         """
         if storage_stage == 'in':
             full_path = os.path.join(self.tables_in_path, name)
@@ -366,7 +369,8 @@ class CommonInterface:
                                    enclosure=enclosure,
                                    delimiter=delimiter,
                                    delete_where=delete_where,
-                                   stage=storage_stage)
+                                   stage=storage_stage,
+                                   write_always=write_always)
 
     def create_in_table_definition(self, name: str,
                                    is_sliced: bool = False,
@@ -410,7 +414,8 @@ class CommonInterface:
                                     table_metadata: dao.TableMetadata = None,
                                     enclosure: str = '"',
                                     delimiter: str = ',',
-                                    delete_where: dict = None) -> dao.TableDefinition:
+                                    delete_where: dict = None,
+                                    write_always: bool = False) -> dao.TableDefinition:
         """
                        Helper method for output dao.TableDefinition creation along with the "manifest".
                        It initializes path in data/tables/out/ folder.
@@ -426,6 +431,8 @@ class CommonInterface:
                            enclosure: str: CSV enclosure, by default "
                            delimiter: str: CSV delimiter, by default ,
                            delete_where: Dict with settings for deleting rows
+                           write_always: Bool: If true, the table will be saved to Storage even when the job execution
+                           fails.
         """
 
         return self._create_table_definition(name=name,
@@ -438,7 +445,8 @@ class CommonInterface:
                                              table_metadata=table_metadata,
                                              enclosure=enclosure,
                                              delimiter=delimiter,
-                                             delete_where=delete_where)
+                                             delete_where=delete_where,
+                                             write_always=write_always)
 
     # # File processing
 

--- a/tests/test_interface.py
+++ b/tests/test_interface.py
@@ -157,7 +157,8 @@ class TestCommonInterface(unittest.TestCase):
                                                    incremental=True,
                                                    delete_where={'column': 'lilly',
                                                                  'values': ['a', 'b'],
-                                                                 'operator': 'eq'}
+                                                                 'operator': 'eq'},
+                                                   write_always=True
                                                    )
         out_table.table_metadata.add_table_metadata('bar', 'kochba')
         out_table.table_metadata.add_column_metadata('bar', 'foo', 'gogo')
@@ -173,6 +174,7 @@ class TestCommonInterface(unittest.TestCase):
                 'columns': ['foo', 'bar'],
                 'primary_key': ['foo'],
                 'incremental': True,
+                'write_always': True,
                 'delimiter': ',',
                 'enclosure': '"',
                 'metadata': [{'key': 'bar', 'value': 'kochba'}],


### PR DESCRIPTION
Added [write_always](https://developers.keboola.com/extend/common-interface/config-file/#output-mapping--write-even-if-the-job-fails) support to Table manifest