### PR TITLE
fix(vcr): suppress vcr/urllib3 debug logging during cassette replay

### DIFF
--- a/src/keboola/component/base.py
+++ b/src/keboola/component/base.py
@@ -272,7 +272,12 @@ class ComponentBase(ABC, CommonInterface):
 
     def _execute_with_vcr_replay(self) -> None:
         """Replay HTTP interactions from data/cassettes/requests.json."""
+        import logging
+
         from keboola.vcr import VCRRecorder
+
+        for name in ("vcr", "urllib3"):
+            logging.getLogger(name).setLevel(logging.WARNING)
 
         data_dir = os.environ.get("KBC_DATADIR", "/data")
         recorder = VCRRecorder(cassette_dir=Path(data_dir) / "cassettes")

--- a/src/keboola/component/base.py
+++ b/src/keboola/component/base.py
@@ -272,8 +272,6 @@ class ComponentBase(ABC, CommonInterface):
 
     def _execute_with_vcr_replay(self) -> None:
         """Replay HTTP interactions from data/cassettes/requests.json."""
-        import logging
-
         from keboola.vcr import VCRRecorder
 
         for name in ("vcr", "urllib3"):


### PR DESCRIPTION
## Summary

- `_execute_with_vcr_replay()` was not suppressing `vcr` and `urllib3` loggers, causing one DEBUG line per cassette interaction to flood stdout during local debug runs (e.g. ~995 lines for a typical Facebook Pages job)
- `record_debug_run()` already suppresses these loggers at WARNING — this brings replay in line with the same behaviour

## Test plan

- [ ] Run component locally with a `data/cassettes/requests.json` present — stdout should only show component-level INFO/WARNING/ERROR, no vcrpy `Appending request...` lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)