### PR TITLE
version input in the Deploy workflow for TestPyPI

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,10 +3,9 @@ name: Build & Deploy to PyPI
 on:
   workflow_dispatch:
     inputs:
-      note:
-        description: 'This workflow publishes to TestPyPI only. For production, create a GitHub Release.'
-        required: false
-        default: ""
+      version:
+        description: Package version (applies to TestPyPI only; for production, create a GitHub release)
+        required: true
 
   release:
     types: [published]
@@ -37,12 +36,12 @@ jobs:
         run: |
           uv run pytest tests
 
-      - name: Version replacement based on tag ↔️
-        if: github.ref_type == 'tag'
+      - name: Version replacement based on workflow input or release tag ↔️
+        if: inputs.version || github.ref_type == 'tag'
         run: |
-          TAG_VERSION=${GITHUB_REF#refs/tags/}
-          echo "Tag version: $TAG_VERSION"
-          uv version $TAG_VERSION
+          VERSION="${{ inputs.version || github.ref_name }}"
+          echo "Setting version: $VERSION"
+          uv version $VERSION
 
       - name: Build package 📦
         run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "keboola.component"
-version = "1.9.0"  # replaced by the actual version based on the release tag in github actions
+version = "0.0.0"  # replaced by the actual version based on the release tag in github actions
 dependencies = [
     "pygelf",
     "deprecated",


### PR DESCRIPTION
### What happened

- The deploy workflow historically used two separate files: deploy.yml (production PyPI, on release) and deploy_to_test.yml (TestPyPI, manual workflow_dispatch)
- Neither workflow supported setting the package version on manual runs — the version step was gated on if: github.ref_type == 'tag', which never matches for workflow_dispatch
- At ae3e0fc, both files were merged into a single deploy.yml with a push: tags trigger — a transitional state during the workflow rework. The `1.7.x` tags were created via Git CLI (git tag + git push) during this window
- At 094e0b6 (`1.7.3`), the trigger was changed to workflow_dispatch (with an environment choice) + release: [published]. The environment input controlled which PyPI index to use but still didn't address versioning
- At 4f76275, the environment input was replaced with a no-op note field
- Net result: since `1.8.0`, manual TestPyPI deploys have had no way to set the package version — they publish whatever is hardcoded in pyproject.toml

### What this PR fixes

- Adds a required version input to workflow_dispatch so manual TestPyPI deploys always have an explicit version
- Updates the version replacement step to use inputs.version for manual runs, github.ref_name (tag) for releases
- Resets pyproject.toml version to 0.0.0 placeholder to prevent accidental publishes with a stale version

### Deploy flow after this change

- Manual TestPyPI deploy: Go to Actions > "Build & Deploy to PyPI" > Run workflow, enter the desired version — publishes to TestPyPI only
- Production release: Create a GitHub Release (with tag) — publishes to both TestPyPI and PyPI, version from tag
- Kindly please use `1.9.x`, `1.11.x` etc. for TestPyPI and `1.10.x`, `1.12.x` etc. for production PyPI. New minor version lines should always start with **0** patch version (eg. test how long you want with `1.9.x`, then use `1.10.0` for the actual release). Thanks! 🙏 